### PR TITLE
Prevent contract account from staking/unstaking

### DIFF
--- a/contracts/MockStaker.sol
+++ b/contracts/MockStaker.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.8.7;
+
+import "./staking.sol";
+
+// This is mock contract to access to StakingContract
+contract MockStaker {
+    Staking _staking;
+
+    constructor(address payable stakingContractAddr) {
+        _staking = Staking(stakingContractAddr);
+    }
+
+    receive() external payable {}
+
+    function transfer(uint256 amount) public {
+        payable(_staking).transfer(amount);
+    }
+
+    function stake(uint256 amount) public {
+        _staking.stake{value: amount}();
+    }
+
+    function unstake() public {
+        _staking.unstake();
+    }
+}

--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.7;
 contract Staking {
     // Parameters
     uint128 public constant ValidatorThreshold = 1 ether;
+    uint32 public constant MinimumRequiredNumValidators = 4;
 
     // Properties
     address[] public _validators;
@@ -68,13 +69,18 @@ contract Staking {
     }
 
     function _unstake() private {
+        require(
+            _validators.length > MinimumRequiredNumValidators,
+            "Number of validators can't be less than MinimumRequiredNumValidators"
+        );
+
         uint256 amount = _addressToStakedAmount[msg.sender];
 
-        _addressToStakedAmount[msg.sender] = 0;
         if (_addressToIsValidator[msg.sender]) {
             _deleteFromValidators(msg.sender);
         }
 
+        _addressToStakedAmount[msg.sender] = 0;
         _stakedAmount -= amount;
         payable(msg.sender).transfer(amount);
         emit Unstaked(msg.sender, amount);

--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -1,10 +1,6 @@
-pragma solidity ^0.8.7;
-
-import "@openzeppelin/contracts/utils/Address.sol";
+pragma solidity ^0.8.0;
 
 contract Staking {
-    using Address for address;
-
     // Parameters
     uint128 public constant ValidatorThreshold = 1 ether;
     uint32 public constant MinimumRequiredNumValidators = 4;
@@ -23,7 +19,12 @@ contract Staking {
 
     // modifiers
     modifier onlyEOA() {
-        require(!msg.sender.isContract(), "Only EOA can call function");
+        address addr = msg.sender;
+        uint256 size;
+        assembly {
+            size := extcodesize(addr)
+        }
+        require(size > 0);
         _;
     }
 

--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -1,6 +1,10 @@
 pragma solidity ^0.8.7;
 
+import "@openzeppelin/contracts/utils/Address.sol";
+
 contract Staking {
+    using Address for address;
+
     // Parameters
     uint128 public constant ValidatorThreshold = 1 ether;
     uint32 public constant MinimumRequiredNumValidators = 4;
@@ -18,6 +22,11 @@ contract Staking {
     event Unstaked(address indexed account, uint256 amount);
 
     // modifiers
+    modifier onlyEOA() {
+        require(!msg.sender.isContract(), "Only EOA can call function");
+        _;
+    }
+
     modifier onlyStaker() {
         require(
             _addressToStakedAmount[msg.sender] > 0,
@@ -38,15 +47,15 @@ contract Staking {
     }
 
     // public functions
-    receive() external payable {
+    receive() external payable onlyEOA {
         _stake();
     }
 
-    function stake() public payable {
+    function stake() public payable onlyEOA {
         _stake();
     }
 
-    function unstake() public onlyStaker {
+    function unstake() public onlyEOA onlyStaker {
         _unstake();
     }
 

--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -24,7 +24,7 @@ contract Staking {
         assembly {
             size := extcodesize(addr)
         }
-        require(size > 0);
+        require(size == 0);
         _;
     }
 

--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -1,6 +1,10 @@
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/utils/Address.sol";
+
 contract Staking {
+    using Address for address;
+
     // Parameters
     uint128 public constant ValidatorThreshold = 1 ether;
     uint32 public constant MinimumRequiredNumValidators = 4;
@@ -19,12 +23,7 @@ contract Staking {
 
     // modifiers
     modifier onlyEOA() {
-        address addr = msg.sender;
-        uint256 size;
-        assembly {
-            size := extcodesize(addr)
-        }
-        require(size == 0);
+        require(!msg.sender.isContract(), "Only EOA can call function");
         _;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "staking_contract",
-  "version": "1.0.0",
+  "name": "staking-contracts",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -749,6 +749,12 @@
         "@types/sinon-chai": "^3.2.3",
         "@types/web3": "1.0.19"
       }
+    },
+    "@openzeppelin/contracts": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.1.tgz",
+      "integrity": "sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==",
+      "dev": true
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.3.1",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.3.0",
     "@types/chai": "^4.2.21",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^4.3.1",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.3.0",
     "@types/chai": "^4.2.21",

--- a/test/staking.ts
+++ b/test/staking.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Staking } from "../types/staking";
 import { Deferrable } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
 
 describe("Staking contract", function () {
   let accounts: SignerWithAddress[];
@@ -92,14 +93,35 @@ describe("Staking contract", function () {
   });
 
   describe("Unstake", () => {
+    const numInitialValidators = 5;
     const stakedAmount = ethers.utils.parseEther("1");
+    const stake = async (account: SignerWithAddress, value: BigNumber) => {
+      return contract.connect(account).stake({ value });
+    };
     beforeEach(async () => {
-      await contract.stake({ value: stakedAmount });
+      // set required number of validators
+      await Promise.all(
+        accounts
+          .slice(0, numInitialValidators)
+          .map((account) => stake(account, stakedAmount))
+      );
     });
 
     it("should failed if an account is not a staker", async () => {
-      await expect(contract.connect(accounts[1]).unstake()).to.be.revertedWith(
-        "Only staker can call function"
+      await expect(
+        contract.connect(accounts[numInitialValidators]).unstake()
+      ).to.be.revertedWith("Only staker can call function");
+    });
+
+    it("should failed if current number of validators equals to MinimumRequiredNumValidators", async () => {
+      // remove 1 account first
+      await contract.connect(accounts[1]).unstake();
+      // current number of validators should be same to 4 (MinimumRequiredNumValidators)
+      await expect(await contract.validators()).to.have.length(4);
+
+      // cannot remove validator anymore
+      await expect(contract.unstake()).to.be.revertedWith(
+        "Number of validators can't be less than MinimumRequiredNumValidators"
       );
     });
 
@@ -119,32 +141,33 @@ describe("Staking contract", function () {
     it("should remove account from validators", async () => {
       await contract.unstake();
       expect(await contract.validators())
-        .to.have.length(0)
+        .to.have.length(numInitialValidators - 1)
         .not.to.include(accounts[0].address);
     });
 
     it("should exchange between 2 addresses in validators when contract remove validator in the middle of array", async () => {
-      // add more 2 validators
-      await Promise.all([
-        contract.connect(accounts[1]).stake({ value: stakedAmount }),
-        contract.connect(accounts[2]).stake({ value: stakedAmount }),
-      ]);
-
       // make sure validators is in order from oldest
       expect(await contract.validators())
-        .to.have.length(3)
+        .to.have.length(numInitialValidators)
         .and.to.deep.equal([
           accounts[0].address,
           accounts[1].address,
           accounts[2].address,
+          accounts[3].address,
+          accounts[4].address,
         ]);
 
-      // unstake first account
+      // first account's unstake
       await contract.unstake();
       expect(await contract.validators())
-        // [0, 1, 2] => [2, 1]
-        .to.have.length(2)
-        .and.to.deep.equal([accounts[2].address, accounts[1].address]);
+        // [0, 1, 2, 3, 4] => [4, 1, 2, 3]
+        .to.have.length(4)
+        .and.to.deep.equal([
+          accounts[4].address,
+          accounts[1].address,
+          accounts[2].address,
+          accounts[3].address,
+        ]);
     });
   });
 });


### PR DESCRIPTION
Prevent contract account from calling stake and unstake in Staking contract, in order that only EOA can stake and unstake for some system constraints

This is forked from #3, please check the change in https://github.com/0xPolygon/staking-contracts/commit/139012b3b11e463c20801cfa6961174819b0093d